### PR TITLE
Added Refresh theme as a Git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 public/
-themes/
 resources/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/hugo-theme-refresh"]
+	path = themes/hugo-theme-refresh
+	url = git@github.com:stuartmccoll/hugo-theme-refresh.git

--- a/config.toml
+++ b/config.toml
@@ -1,17 +1,17 @@
 baseurl = "https://stuartmccoll.github.io"
 title = "Stuart McColl"
 languageCode = "en"
-theme = "refresh"
+theme = "hugo-theme-refresh"
 
 pygmentsStyle = "github"
 pygmentsUseClasses = true
 pygmentsCodeFencers = true
 
 [author]
-    name = "Stuart McColl"
+  name = "Stuart McColl"
 
 [taxonomies]
-    tag = "tags"
+  tag = "tags"
 
 [params]
   dateform        = "Jan 2, 2006"
@@ -23,40 +23,41 @@ pygmentsCodeFencers = true
   keywords = "homepage, blog, development, programming"
   images = [""]
   contentTypeName = "posts"
+
+  title = "Stuart McColl"
   
   # Flag to toggle inclusion of license information
-    includeLicense = true
+  includeLicense = true
 
-    # Type of attribution license to use
-    licenseType = "CC BY 4.0"
+  # Type of attribution license to use
+  licenseType = "CC BY 4.0"
 
-    # Link to attribution license
-    licenseLink = "https://creativecommons.org/licenses/by/4.0"
+  # Link to attribution license
+  licenseLink = "https://creativecommons.org/licenses/by/4.0"
 
-    # Flag to toggle inclusion of GitHub issues link
-    includeIssues = true
+  # Flag to toggle inclusion of GitHub issues link
+  includeIssues = true
 
-    # Link to create a new GitHub issue
-    issuesLink = "https://github.com/stuartmccoll/hugo-theme-refresh/issues/new"
+  # Link to create a new GitHub issue
+  issuesLink = "https://github.com/stuartmccoll/hugo-theme-refresh/issues/new"
 
-    # Flag to toggle inclusion of Twitter link
-    includeTwitter = true
+  # Flag to toggle inclusion of Twitter link
+  includeTwitter = true
 
-    # Twitter username
-    twitterUsername = "itstuartmccoll"
+  # Twitter username
+  twitterUsername = "itstuartmccoll"
 
-    # Flag to toggle inclusion of Hugo version details
-    includeHugoVersion = true
+  # Flag to toggle inclusion of Hugo version details
+  includeHugoVersion = true
 
 [markup]
   [markup.highlight]
-    codeFences = true
-    guessSyntax = false
-    hl_Lines = ""
-    lineNoStart = 1
-    lineNos = false
-    lineNumbersInTable = true
-    noClasses = true
-    style = "github"
-    tabWidth = 4
-  
+  codeFences = true
+  guessSyntax = false
+  hl_Lines = ""
+  lineNoStart = 1
+  lineNos = false
+  lineNumbersInTable = true
+  noClasses = true
+  style = "github"
+  tabWidth = 4


### PR DESCRIPTION
This commit adds the Refresh theme as a Git submodule and contains some minor amendments to the `config.toml` configuration file to allow for this.

Closes #4.